### PR TITLE
Mock certificate generation: set start date in the past, add SAN extension

### DIFF
--- a/NonHTTPProxy/src/josh/nonHttp/DynamicKeyStore.java
+++ b/NonHTTPProxy/src/josh/nonHttp/DynamicKeyStore.java
@@ -25,6 +25,8 @@ import java.util.Date;
 import javax.security.auth.x500.X500Principal;
 import org.bouncycastle.asn1.DERSequence;
 import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.asn1.x509.ExtendedKeyUsage;
+import org.bouncycastle.asn1.x509.KeyPurposeId;
 import org.bouncycastle.asn1.x509.X509Extensions;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.x509.X509V3CertificateGenerator;
@@ -64,6 +66,7 @@ public class DynamicKeyStore {
 		certGen.setPublicKey(pubKey);
 		certGen.setSignatureAlgorithm("SHA256withRSA");
 		certGen.addExtension(X509Extensions.SubjectAlternativeName, true, new DERSequence(new GeneralName(GeneralName.dNSName,cn)));
+		certGen.addExtension(X509Extensions.ExtendedKeyUsage, true, new ExtendedKeyUsage(KeyPurposeId.id_kp_serverAuth));
 		
 
 		/*certGen.addExtension(X509Extensions.AuthorityKeyIdentifier, false,
@@ -109,6 +112,7 @@ public class DynamicKeyStore {
 		certGen.setPublicKey(pubKey);
 		certGen.setSignatureAlgorithm("SHA256withRSA");
 		certGen.addExtension(X509Extensions.SubjectAlternativeName, true, new DERSequence(new GeneralName(GeneralName.dNSName,cn)));
+		certGen.addExtension(X509Extensions.ExtendedKeyUsage, true, new ExtendedKeyUsage(KeyPurposeId.id_kp_serverAuth));
 
 		//
 		// extensions
@@ -182,11 +186,11 @@ public class DynamicKeyStore {
 	        //char[] pw = password.toCharArray();
 	        char[] pw = "changeit".toCharArray();
 	        KeyPairGenerator r = KeyPairGenerator.getInstance("RSA");
-			r.initialize(1024);
+			r.initialize(2048);
 			KeyPair intkeyPair = r.generateKeyPair();
 			
 			KeyPairGenerator r1 = KeyPairGenerator.getInstance("RSA");
-			r1.initialize(1024);
+			r1.initialize(2048);
 			KeyPair keyPair = r1.generateKeyPair();
 		
 	        

--- a/NonHTTPProxy/src/josh/nonHttp/DynamicKeyStore.java
+++ b/NonHTTPProxy/src/josh/nonHttp/DynamicKeyStore.java
@@ -23,6 +23,9 @@ import java.security.cert.X509Certificate;
 import java.util.Calendar;
 import java.util.Date;
 import javax.security.auth.x500.X500Principal;
+import org.bouncycastle.asn1.DERSequence;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.asn1.x509.X509Extensions;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.x509.X509V3CertificateGenerator;
 
@@ -83,7 +86,10 @@ public class DynamicKeyStore {
 		final int daysTillExpiry = 10 * 365;
 
 	    final Calendar expiry = Calendar.getInstance();
+	    final Calendar start = Calendar.getInstance();
 	    expiry.add(Calendar.DAY_OF_YEAR, daysTillExpiry);
+// Set the start date of the certificate to a week ago to make sure it is considered valid
+	    start.add(Calendar.DAY_OF_YEAR, -7);
 		
 		
 		
@@ -93,11 +99,12 @@ public class DynamicKeyStore {
 
 		certGen.setSerialNumber(java.math.BigInteger.valueOf(System.currentTimeMillis()));
 		certGen.setIssuerDN(caCert.getSubjectX500Principal());
-		certGen.setNotBefore(new Date());
+		certGen.setNotBefore(start.getTime());
 		certGen.setNotAfter(expiry.getTime());
 		certGen.setSubjectDN(subjectName);
 		certGen.setPublicKey(pubKey);
 		certGen.setSignatureAlgorithm("SHA256withRSA");
+		certGen.addExtension(X509Extensions.SubjectAlternativeName, true, new DERSequence(new GeneralName(GeneralName.dNSName,cn)));
 
 		//
 		// extensions

--- a/NonHTTPProxy/src/josh/nonHttp/DynamicKeyStore.java
+++ b/NonHTTPProxy/src/josh/nonHttp/DynamicKeyStore.java
@@ -40,10 +40,13 @@ public class DynamicKeyStore {
 									String cn, String o, String ou, String l, String st, String c
 									) throws InvalidKeyException, IllegalStateException, NoSuchProviderException, NoSuchAlgorithmException, SignatureException, CertificateException, IOException{
 		
-		final int daysTillExpiry = 10 * 365;
+		final int daysTillExpiry = 365;
 
 	    final Calendar expiry = Calendar.getInstance();
+	    final Calendar start = Calendar.getInstance();
 	    expiry.add(Calendar.DAY_OF_YEAR, daysTillExpiry);
+// Set the start date of the certificate to a week ago to make sure it is considered valid
+	    start.add(Calendar.DAY_OF_YEAR, -7);
 
 	   /*X509v3CertificateBuilder certBuilder = new X509v3CertificateBuilder(new X500Name("CN="+cn+", OU="+ou+", O="+o+", L="+l),BigInteger.valueOf(new SecureRandom().nextLong()), new Date(), expiry.getTime(), new X500Name("CN=PortSwigger CA"), SubjectPublicKeyInfo.getInstance(pubKey.getEncoded()));
 	    byte[] certBytes = certBuilder.build(new JCESigner(intPrivKey, "SHA256withRSA")).getEncoded();
@@ -55,11 +58,12 @@ public class DynamicKeyStore {
 
 		certGen.setSerialNumber(java.math.BigInteger.valueOf(System.currentTimeMillis()));
 		certGen.setIssuerDN(cacertPrin);
-		certGen.setNotBefore(new Date());
+		certGen.setNotBefore(start.getTime());
 		certGen.setNotAfter(expiry.getTime());
 		certGen.setSubjectDN(subjectName);
 		certGen.setPublicKey(pubKey);
 		certGen.setSignatureAlgorithm("SHA256withRSA");
+		certGen.addExtension(X509Extensions.SubjectAlternativeName, true, new DERSequence(new GeneralName(GeneralName.dNSName,cn)));
 		
 
 		/*certGen.addExtension(X509Extensions.AuthorityKeyIdentifier, false,

--- a/NonHTTPProxy/src/josh/nonHttp/DynamicKeyStore.java
+++ b/NonHTTPProxy/src/josh/nonHttp/DynamicKeyStore.java
@@ -83,7 +83,7 @@ public class DynamicKeyStore {
 										X509Certificate caCert,
 										String cn, String o, String ou, String l, String st, String c
 										) throws InvalidKeyException, IllegalStateException, NoSuchProviderException, NoSuchAlgorithmException, SignatureException, CertificateException{
-		final int daysTillExpiry = 10 * 365;
+		final int daysTillExpiry = 365;
 
 	    final Calendar expiry = Calendar.getInstance();
 	    final Calendar start = Calendar.getInstance();


### PR DESCRIPTION
When testing the SSL functionalities provided by the extension by having it proxy HTTPS requests to arbitrary websites coming from a Windows 10 machine via Microsoft Edge, it is possible to notice that the mock certificate which is generated on-the-fly to impersonate the contacted server fails verification because of two issues:
1. The "not before" property value is set to the exact time at which the certificate itself is generated; since the certificate is presented to the browser immediately after it was generated, even a minimal amount of desynchronization between the machine hosting the proxy and the client might cause a failed verification error.
2. The certificate lacks the "Subject Alternative Name" extension; given that the contents of this extension are often being used in place of the "Common Name" field to perform validity checks on the contacted hostname, it not being present at all can also raise failed verification errors.

As such, the objective of this pull request is to propose a fix to the two issues mentioned above by, respectively:
1. Setting the "not before" property to 7 days before the time of certificate generation programmatically.
2. Introducing the Subject Alternative Name extension with the DNS name for the proxied server (assumed to be the same as the Common Name).

Notice that the code is currently using several deprecated classes from the BouncyCastle API; a refactoring in that regard was not in the scope of this pull request.